### PR TITLE
Fixed incorrect variable declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,15 +77,15 @@ class Broadlink extends EventEmitter {
       const payload = Buffer.alloc(0x88, 0);
       payload[0x26] = 0x14;
 
-      ssidStart = 68;
-      ssidLength = 0;
+      const ssidStart = 68;
+      let ssidLength = 0;
       for (let letter of ssid) {
         payload[ssidStart + ssidLength] = letter.charCodeAt(0);
         ssidLength += 1;
       }
 
-      passStart = 100;
-      passLength = 0;
+      const passStart = 100;
+      let passLength = 0;
       for (let letter of password) {
         payload[passStart + passLength] = letter.charCodeAt(0);
         passLength += 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broadlinkjs-rm",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Incorrect variable declaration was causing `ReferenceError: ssidStart is not defined`